### PR TITLE
change 'one row per author' to 'one author per row'

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,8 @@ name | name
 No Starch Press | Python Made Easy
 No Starch Press | JavaScript: The Really Good Parts
 
-#### Show a list of every book and their authors (one author per row)
+#### Show a list of every book and their authors
+Note: Only one author per row, so the book's name may need to be repeated.
 
 ##### Expected result
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ name | name
 No Starch Press | Python Made Easy
 No Starch Press | JavaScript: The Really Good Parts
 
-#### Show a list of every book and their authors (one row per author)
+#### Show a list of every book and their authors (one author per row)
 
 ##### Expected result
 


### PR DESCRIPTION
Change instruction, because "one row per author" implies that students won't see an author repeated (which they do)

Should read "one author per row", because students may be confused if they see the name of a single book repeated multiple times.

fixes #8

requires @pbywater's review